### PR TITLE
[FEAT] 엔티티를 추가한다.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,10 +1,11 @@
-dependencies {
-}
-
 bootJar {
     enabled = false
 }
 
 jar {
     enabled = true
+}
+
+dependencies {
+    implementation project(':core')
 }

--- a/core/src/main/java/com/core/core/domain/exercise/Exercise.java
+++ b/core/src/main/java/com/core/core/domain/exercise/Exercise.java
@@ -1,0 +1,22 @@
+package com.core.core.domain.exercise;
+
+import com.core.core.global.entity.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Exercise extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String description;
+}

--- a/core/src/main/java/com/core/core/domain/exercise/repository/ExerciseRepository.java
+++ b/core/src/main/java/com/core/core/domain/exercise/repository/ExerciseRepository.java
@@ -1,0 +1,7 @@
+package com.core.core.domain.exercise.repository;
+
+import com.core.core.domain.exercise.Exercise;
+import org.springframework.data.repository.Repository;
+
+public interface ExerciseRepository extends Repository<Exercise, Long> {
+}

--- a/core/src/main/java/com/core/core/domain/record/Certificate.java
+++ b/core/src/main/java/com/core/core/domain/record/Certificate.java
@@ -1,0 +1,19 @@
+package com.core.core.domain.record;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Certificate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String uri;
+}

--- a/core/src/main/java/com/core/core/domain/record/Certificate.java
+++ b/core/src/main/java/com/core/core/domain/record/Certificate.java
@@ -14,6 +14,10 @@ public class Certificate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CertificateType type;
+
     @Column(nullable = false)
     private String uri;
 }

--- a/core/src/main/java/com/core/core/domain/record/CertificateType.java
+++ b/core/src/main/java/com/core/core/domain/record/CertificateType.java
@@ -1,0 +1,14 @@
+package com.core.core.domain.record;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CertificateType {
+    VIDEO("video"),
+    PHOTO("photo");
+
+    private final String typeName;
+}

--- a/core/src/main/java/com/core/core/domain/record/Record.java
+++ b/core/src/main/java/com/core/core/domain/record/Record.java
@@ -28,5 +28,8 @@ public class Record extends BaseEntity {
     @Column(nullable = false)
     private Integer measurement;
 
-
+    @OneToOne
+    @JoinColumn(name = "certificate_id")
+    @Column(nullable = true)
+    private Certificate certificate;
 }

--- a/core/src/main/java/com/core/core/domain/record/Record.java
+++ b/core/src/main/java/com/core/core/domain/record/Record.java
@@ -1,0 +1,32 @@
+package com.core.core.domain.record;
+
+import com.core.core.domain.exercise.Exercise;
+import com.core.core.domain.user.User;
+import com.core.core.global.entity.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Record extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "exercise_id")
+    private Exercise exercise;
+
+    @Column(nullable = false)
+    private Integer measurement;
+
+
+}

--- a/core/src/main/java/com/core/core/domain/record/repository/CertificateRepository.java
+++ b/core/src/main/java/com/core/core/domain/record/repository/CertificateRepository.java
@@ -1,0 +1,7 @@
+package com.core.core.domain.record.repository;
+
+import com.core.core.domain.record.Certificate;
+import org.springframework.data.repository.Repository;
+
+public interface CertificateRepository extends Repository<Certificate, Long> {
+}

--- a/core/src/main/java/com/core/core/domain/record/repository/RecordRepository.java
+++ b/core/src/main/java/com/core/core/domain/record/repository/RecordRepository.java
@@ -1,0 +1,7 @@
+package com.core.core.domain.record.repository;
+
+import com.core.core.domain.record.Record;
+import org.springframework.data.repository.Repository;
+
+public interface RecordRepository extends Repository<Record, Long> {
+}

--- a/core/src/main/java/com/core/core/domain/user/Gender.java
+++ b/core/src/main/java/com/core/core/domain/user/Gender.java
@@ -1,0 +1,15 @@
+package com.core.core.domain.user;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Gender {
+    MALE("male", "남자"),
+    FEMALE("female", "여자");
+
+    private final String engValue;
+    private final String korValue;
+}

--- a/core/src/main/java/com/core/core/domain/user/Provider.java
+++ b/core/src/main/java/com/core/core/domain/user/Provider.java
@@ -1,0 +1,14 @@
+package com.core.core.domain.user;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Provider {
+    NAVER("naver"),
+    KAKAO("kakao");
+
+    private final String providerName;
+}

--- a/core/src/main/java/com/core/core/domain/user/User.java
+++ b/core/src/main/java/com/core/core/domain/user/User.java
@@ -1,0 +1,43 @@
+package com.core.core.domain.user;
+
+import com.core.core.global.entity.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String socialId;
+
+    @Column(nullable = false)
+    private Provider provider;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false)
+    private Double height;
+
+    @Column(nullable = false)
+    private Double weight;
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "false")
+    private boolean agreedKakaoMarketing;
+
+
+}

--- a/core/src/main/java/com/core/core/domain/user/User.java
+++ b/core/src/main/java/com/core/core/domain/user/User.java
@@ -25,6 +25,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Column(nullable = false)
+    private int age;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;

--- a/core/src/main/java/com/core/core/domain/user/repository/UserRepository.java
+++ b/core/src/main/java/com/core/core/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.core.core.domain.user.repository;
+
+import com.core.core.domain.user.User;
+import org.springframework.data.repository.Repository;
+
+public interface UserRepository extends Repository<User, Long> {
+}

--- a/core/src/main/java/com/core/core/global/entity/BaseEntity.java
+++ b/core/src/main/java/com/core/core/global/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.core.core.global.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static final String TIME_ZONE = "Asia/Seoul";
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT,
+            timezone = TIME_ZONE)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT,
+            timezone = TIME_ZONE)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
 ## 📌 관련 이슈
- closed #6 

## ✨ 구현 내용
- 각 엔티티 추가

## 💬 논의 사항
1. certificate 에서 enum 이 뭐가 들어가야할지 몰라서 우선은 빼고 푸쉬했습니다! 알려주시면 감사하겠습니닷.
2. enum 에서 어떤 필드가 필요할지 몰라서 우선은 문자열로 넣어두기는 했는데 의견 주시면 좋을 것 같아요!
3. RefreshToken 엔티티를 추가하지 않았는데.. 그 이유는 이게 도메인 관련 로직인지에 대한 의문이 커서요!.. 멀티모듈 환경이 아닌 경우에도 항상 domain 과는 별도로 auth 관련 디렉토리를 두어서 했었어서.. 뭐가 맞을지 모르겠네요. 의견 주시면 좋을 것 같습니다! 차라리 api 에 넣어볼까 했는데 api 는 정말 클라이언트단과 소통하는 창구로만 쓰고 싶다는 욕심이 커서.. 어디가 좋을까요?
아니면 그냥 User 에 포함시킬까 싶기도 하고..
4. social_id 만 있으면 해당 유저가 어떤 플랫폼으로 로그인 했는지 모를 것 같아서 provider 컬럼을 추가하고 enum 으로 생성해뒀습니다.