### PR TITLE
[FIX] DNS설정 변경, EC2가 ami가 업데이트될때마다 새로 생성되던 버그 수정

### DIFF
--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -53,6 +53,12 @@ resource "aws_instance" "master_node_1" {
   }
 
   iam_instance_profile = aws_iam_instance_profile.k8s_instance_profile.name
+
+  lifecycle {
+    ignore_changes = [
+      ami, user_data
+    ]
+  }
 }
 
 resource "aws_instance" "worker_node_1" {
@@ -72,5 +78,11 @@ resource "aws_instance" "worker_node_1" {
 
   tags = {
     Name = "worker-node-1"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      ami, user_data
+    ]
   }
 }

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -20,7 +20,7 @@ resource "aws_route53_record" "vercel" {
   records = ["76.76.21.21"]
 }
 
-resource "aws_route53_record" "www" {
+resource "aws_route53_record" "www_to_root" {
   zone_id = aws_route53_zone.primary.zone_id
   name    = "www.chinda.kr"
   type    = "CNAME"

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -1,10 +1,36 @@
+variable "domain_name" {
+  type    = string
+  default = "chinda.kr"
+}
+
+variable "vercel_ip_address" {
+  type    = string
+  default = "76.76.21.21"
+}
+
 resource "aws_route53_zone" "primary" {
-  name = "chinda.kr"
+  name = var.domain_name
+}
+
+resource "aws_route53_record" "vercel" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.domain_name
+  type    = "A"
+  ttl     = "30"
+  records = ["76.76.21.21"]
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "www.chinda.kr"
+  type    = "CNAME"
+  ttl     = "30"
+  records = [var.domain_name]
 }
 
 resource "aws_route53_record" "api" {
   zone_id = aws_route53_zone.primary.zone_id
-  name    = "api.chinda.kr"
+  name    = "api.${var.domain_name}"
   type    = "A"
   ttl     = "30"
   records = [aws_instance.master_node_1.public_ip, aws_instance.worker_node_1.public_ip]


### PR DESCRIPTION
 ## 📌 관련 이슈
- closed #21 

## ✨ 구현 내용
- 루트도메인에 vercel을, api 서브도메인에 인스턴스 주소 매핑
- EC2 ami 고정

## 테스트 방법
- www.chinda.kr 접속 -> 프런트 페이지 확인
- chinda.kr 접속 -> 프런트 페이지 확인
- api.chinda.kr:30000 접속 -> nginx welcome 페이지 확인